### PR TITLE
Fix network chainId usage

### DIFF
--- a/src/lib/AdapterWalletConnector.ts
+++ b/src/lib/AdapterWalletConnector.ts
@@ -20,7 +20,7 @@ export class AdapterWalletConnector implements WalletConnectorPort {
 
   constructor(private networkConfig: NetworkConfigPort) {
     this.adapter = new PactWalletAdapter({
-      chainId: this.networkConfig.getConfig().chainwebId,
+      chainId: this.networkConfig.getConfig().chainId,
     });
   }
 

--- a/src/lib/NetworkConfig.ts
+++ b/src/lib/NetworkConfig.ts
@@ -11,7 +11,8 @@ import { NetworkConfig, NetworkConfigPort } from '../ports/NetworkConfigPort';
 export class DefaultNetworkConfig implements NetworkConfigPort {
   private config: NetworkConfig = {
     chainwebId: 'testnet04',
-    rpcHost: 'https://api.testnet.chainweb.com', 
+    chainId: '0',
+    rpcHost: 'https://api.testnet.chainweb.com',
     apiHost: 'https://api.testnet.chainweb.com',
     gasPrice: 0.00000001, // Example: 1 * 10^-8 KDA
     gasLimit: 1000,

--- a/src/lib/SpireKeyConnector.ts
+++ b/src/lib/SpireKeyConnector.ts
@@ -20,7 +20,7 @@ export class SpireKeyConnector implements WalletConnectorPort {
 
   constructor(private networkConfig: NetworkConfigPort) {
     this.spire = new SpireKey({
-      chainId: this.networkConfig.getConfig().chainwebId,
+      chainId: this.networkConfig.getConfig().chainId,
     });
   }
 

--- a/src/lib/TransactionSigner.ts
+++ b/src/lib/TransactionSigner.ts
@@ -34,7 +34,7 @@ export class TransactionSigner implements TransactionSignerPort {
       return { txHash: null, error: 'Invalid address' };
     }
 
-    const { chainwebId, gasPrice, gasLimit } = this.networkConfig.getConfig();
+    const { chainwebId, chainId, gasPrice, gasLimit } = this.networkConfig.getConfig();
     const gas = {
       gasPrice: params.gasPrice ?? gasPrice,
       gasLimit: params.gasLimit ?? gasLimit,
@@ -45,7 +45,7 @@ export class TransactionSigner implements TransactionSignerPort {
         from: address,
         to: params.to,
         amount: params.amount,
-        chainId: chainwebId,
+        chainId: chainId,
         gas,
       });
       const result = await submitTransaction(txCommand);

--- a/src/ports/NetworkConfigPort.ts
+++ b/src/ports/NetworkConfigPort.ts
@@ -8,6 +8,7 @@
  */
 export interface NetworkConfig {
   chainwebId: string;   // e.g., 'testnet04'
+  chainId: string;      // chain id within the network, e.g., '0'
   rpcHost: string;      // RPC endpoint
   apiHost: string;      // API endpoint for transactions
   gasPrice: number;     // Default gas price

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -8,6 +8,7 @@
  */
 export interface NetworkConfig {
   chainwebId: string;
+  chainId: string;
   rpcHost: string;
   apiHost: string;
   gasPrice: number;

--- a/tests/lib/NetworkConfig.test.ts
+++ b/tests/lib/NetworkConfig.test.ts
@@ -5,6 +5,7 @@ describe('DefaultNetworkConfig', () => {
     const configProvider = new DefaultNetworkConfig();
     const config = configProvider.getConfig();
     expect(config.chainwebId).toBe('testnet04');
+    expect(config.chainId).toBe('0');
     expect(config.rpcHost).toContain('testnet');
     expect(typeof config.gasPrice).toBe('number');
     expect(typeof config.gasLimit).toBe('number');


### PR DESCRIPTION
## Summary
- support chainId in NetworkConfig
- use chainId when initializing wallet connectors
- use chainId when preparing transfers
- update type definitions and tests

## Testing
- `npx jest` *(fails: needs jest install)*

------
https://chatgpt.com/codex/tasks/task_e_68416ea997608333bb81dab74136cc87