### PR TITLE
Handle adapter returning array from requestAccounts

### DIFF
--- a/src/lib/AdapterWalletConnector.ts
+++ b/src/lib/AdapterWalletConnector.ts
@@ -29,11 +29,17 @@ export class AdapterWalletConnector implements WalletConnectorPort {
    */
   async connect(): Promise<WalletConnectionResult> {
     try {
-      const addr: string = await this.adapter.requestAccounts();
-      this.address = addr;
+      const result: string | string[] = (await (this.adapter as any).requestAccounts()) as
+        | string
+        | string[];
+      const addr = Array.isArray(result) ? result[0] : result;
+      this.address = addr ?? null;
       return { address: this.address, error: null };
     } catch (err: any) {
-      return { address: null, error: err.message || 'Error connecting via extension' };
+      return {
+        address: null,
+        error: err.message || 'Error connecting via extension',
+      };
     }
   }
 

--- a/src/types/wallet-adapter-core.d.ts
+++ b/src/types/wallet-adapter-core.d.ts
@@ -1,0 +1,7 @@
+declare module '@kadena/wallet-adapter-core' {
+  export class PactWalletAdapter {
+    constructor(options: any);
+    requestAccounts(): Promise<string | string[]>;
+    disconnect(): Promise<void>;
+  }
+}

--- a/tests/lib/AdapterWalletConnector.test.ts
+++ b/tests/lib/AdapterWalletConnector.test.ts
@@ -1,0 +1,53 @@
+import { AdapterWalletConnector } from '../../src/lib/AdapterWalletConnector';
+import { NetworkConfigPort } from '../../src/ports/NetworkConfigPort';
+
+// Create a fake network config
+class FakeNetwork implements NetworkConfigPort {
+  getConfig() {
+    return {
+      chainwebId: 'testnet04',
+      rpcHost: '',
+      apiHost: '',
+      gasPrice: 0.00000001,
+      gasLimit: 1000,
+    };
+  }
+}
+
+// Mocks for PactWalletAdapter
+const mockRequestAccounts = jest.fn();
+const mockDisconnect = jest.fn();
+
+jest.mock('@kadena/wallet-adapter-core', () => {
+  return {
+    PactWalletAdapter: jest.fn().mockImplementation(() => ({
+      requestAccounts: mockRequestAccounts,
+      disconnect: mockDisconnect,
+    })),
+  };
+});
+
+describe('AdapterWalletConnector', () => {
+  beforeEach(() => {
+    mockRequestAccounts.mockReset();
+    mockDisconnect.mockReset();
+  });
+
+  test('connect stores first item when adapter returns array', async () => {
+    mockRequestAccounts.mockResolvedValue(['k:addr1', 'k:addr2']);
+    const connector = new AdapterWalletConnector(new FakeNetwork());
+    const result = await connector.connect();
+    expect(result.address).toBe('k:addr1');
+    expect(result.error).toBeNull();
+    expect(connector.getAddress()).toBe('k:addr1');
+  });
+
+  test('connect stores value directly when adapter returns string', async () => {
+    mockRequestAccounts.mockResolvedValue('k:singleAddr');
+    const connector = new AdapterWalletConnector(new FakeNetwork());
+    const result = await connector.connect();
+    expect(result.address).toBe('k:singleAddr');
+    expect(result.error).toBeNull();
+    expect(connector.getAddress()).toBe('k:singleAddr');
+  });
+});


### PR DESCRIPTION
## Summary
- handle array results from `requestAccounts` in `AdapterWalletConnector`
- provide type declaration for mocked PactWalletAdapter
- add tests covering array vs string account results

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841749a1a948333954d5ce4dc3aa8e2