### PR TITLE
Add dev and production scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ npm test
 
 ## Running the Example Web App
 
-The web UI is located in the `webapp` folder and uses Vite. Install the
-dependencies and start the dev server:
+The web UI is located in the `webapp` folder and uses Vite. You can
+start the dev server directly from the project root:
 
 ```bash
-cd webapp
 npm install
 npm run dev
+```
+
+To build the library and web UI and preview the production build run:
+
+```bash
+npm run build
+npm run prod
 ```
 
 Open <http://localhost:5173> in your browser. From the first screen you

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Core logic for Simple Wallet Clone (Kadena), without UI.",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "dev": "npm --prefix webapp run dev",
+    "build": "tsc && npm --prefix webapp run build",
+    "prod": "npm --prefix webapp run preview"
   },
   "dependencies": {
     "@kadena/wallet-adapter-core": "^0.0.1-beta.2",

--- a/tests/lib/AdapterWalletConnector.test.ts
+++ b/tests/lib/AdapterWalletConnector.test.ts
@@ -6,6 +6,7 @@ class FakeNetwork implements NetworkConfigPort {
   getConfig() {
     return {
       chainwebId: 'testnet04',
+      chainId: '0',
       rpcHost: '',
       apiHost: '',
       gasPrice: 0.00000001,


### PR DESCRIPTION
## Summary
- add scripts for dev, build, and prod
- document new commands
- fix failing TypeScript tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684177bba6508333be71bb52dc24f87d