### PR TITLE
Update adapter to use Ecko Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@kadena/wallet-adapter-core": "^0.0.1-beta.2",
+    "@kadena/wallet-adapter-ecko": "^0.0.1-beta.2",
     "@kadena/spirekey-sdk": "^1.0.1",
     "@kadena/wallet-sdk": "^0.2.1",
     "cross-fetch": "^3.1.5"

--- a/src/lib/AdapterWalletConnector.ts
+++ b/src/lib/AdapterWalletConnector.ts
@@ -20,8 +20,8 @@ export class AdapterWalletConnector implements WalletConnectorPort {
   private address: Address = null;
 
   constructor(private networkConfig: NetworkConfigPort) {
-    const chainId = this.networkConfig.getConfig().chainId;
-    this.client = new WalletAdapterClient([eckoAdapter({ networkId: chainId })]);
+    const networkId = this.networkConfig.getConfig().chainwebId;
+    this.client = new WalletAdapterClient([eckoAdapter({ networkId })]);
   }
 
   /**

--- a/src/types/wallet-adapter-core.d.ts
+++ b/src/types/wallet-adapter-core.d.ts
@@ -1,7 +1,0 @@
-declare module '@kadena/wallet-adapter-core' {
-  export class PactWalletAdapter {
-    constructor(options: any);
-    requestAccounts(): Promise<string | string[]>;
-    disconnect(): Promise<void>;
-  }
-}

--- a/tests/lib/AdapterWalletConnector.test.ts
+++ b/tests/lib/AdapterWalletConnector.test.ts
@@ -28,14 +28,17 @@ jest.mock('@kadena/wallet-adapter-core', () => {
   };
 });
 
-jest.mock('@kadena/wallet-adapter-ecko', () => ({
-  eckoAdapter: jest.fn(() => ({ name: 'Ecko' })),
-}));
+var mockEckoAdapter: jest.Mock;
+jest.mock('@kadena/wallet-adapter-ecko', () => {
+  mockEckoAdapter = jest.fn(() => ({ name: 'Ecko' }));
+  return { eckoAdapter: mockEckoAdapter };
+});
 
 beforeEach(() => {
   mockInit.mockReset();
   mockConnect.mockReset();
   mockDisconnect.mockReset();
+  mockEckoAdapter.mockReset();
 });
 
 describe('AdapterWalletConnector', () => {
@@ -43,6 +46,7 @@ describe('AdapterWalletConnector', () => {
     mockConnect.mockResolvedValue({ accountName: 'k:addr1' });
     const connector = new AdapterWalletConnector(new FakeNetwork());
     const result = await connector.connect();
+    expect(mockEckoAdapter).toHaveBeenCalledWith({ networkId: 'testnet04' });
     expect(mockInit).toHaveBeenCalled();
     expect(mockConnect).toHaveBeenCalledWith('Ecko');
     expect(result.address).toBe('k:addr1');
@@ -55,6 +59,7 @@ describe('AdapterWalletConnector', () => {
     const connector = new AdapterWalletConnector(new FakeNetwork());
     await connector.connect();
     await connector.disconnect();
+    expect(mockEckoAdapter).toHaveBeenCalledWith({ networkId: 'testnet04' });
     expect(mockDisconnect).toHaveBeenCalledWith('Ecko');
     expect(connector.getAddress()).toBeNull();
   });


### PR DESCRIPTION
## Summary
- use WalletAdapterClient with the Ecko wallet adapter
- remove outdated custom type definitions
- update tests for new connection workflow
- add `@kadena/wallet-adapter-ecko` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684182c48c048333b05e59fe6892a541