### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "dev": "npm --prefix webapp run dev",
     "build": "tsc -p tsconfig.build.json && npm --prefix webapp run build",
+    "postinstall": "npm --prefix webapp install",
     "prod": "npm --prefix webapp run preview"
   },
   "dependencies": {

--- a/src/lib/TransactionSigner.ts
+++ b/src/lib/TransactionSigner.ts
@@ -42,7 +42,7 @@ export class TransactionSigner implements TransactionSignerPort {
     };
 
     try {
-      const unsignedCmd = walletSdk.createSimpleTransfer({
+      const unsignedCmd = await walletSdk.createTransfer({
         sender: address,
         receiver: params.to,
         amount: String(params.amount),


### PR DESCRIPTION
## Summary
- fix signAndSend to use walletSdk.createTransfer
- automatically install webapp deps after `npm install`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68418dea329c833384483e628d18a478