### PR TITLE
Add React wallet context

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,13 @@
   "devDependencies": {
     "@types/events": "^3.0.3",
     "@types/node": "^22.15.30",
+    "@types/react": "^18.2.57",
+    "@types/react-dom": "^18.2.17",
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@kadena/wallet-sdk": "^0.2.1"
+    "@kadena/wallet-sdk": "^0.2.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,0 +1,15 @@
+import React, { createContext, useContext } from 'react';
+import { createWalletEnvironment, WalletEnvironmentServices } from '@infra/sdk/createWalletEnvironment';
+
+const walletEnv: WalletEnvironmentServices = createWalletEnvironment(
+  'https://api.testnet.chainweb.com',
+  'testnet04',
+);
+
+const WalletContext = createContext<WalletEnvironmentServices>(walletEnv);
+
+export const WalletProvider: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+  <WalletContext.Provider value={walletEnv}>{children}</WalletContext.Provider>
+);
+
+export const useWallet = (): WalletEnvironmentServices => useContext(WalletContext);

--- a/src/core/application/ports/WalletConnectorPort.ts
+++ b/src/core/application/ports/WalletConnectorPort.ts
@@ -15,6 +15,11 @@ export interface WalletConnectorPort {
   disconnect(): Promise<void>;
 
   /**
+   * Check whether the wallet is currently connected.
+   */
+  isConnected(): Promise<boolean>;
+
+  /**
    * Retrieve the currently connected account address. Returns `null`
    * if the wallet is not connected.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export const init = () => {};
+
+export { WalletProvider, useWallet } from '@context/WalletContext';

--- a/src/infra/mock/DummyWalletConnector.ts
+++ b/src/infra/mock/DummyWalletConnector.ts
@@ -22,6 +22,10 @@ export class DummyWalletConnector implements WalletConnectorPort {
     this.connected = false;
   }
 
+  async isConnected(): Promise<boolean> {
+    return this.connected;
+  }
+
   async getAddress(): Promise<string | null> {
     return this.connected ? this.address : null;
   }

--- a/src/infra/sdk/WalletSDKConnector.ts
+++ b/src/infra/sdk/WalletSDKConnector.ts
@@ -35,6 +35,10 @@ export class WalletSDKConnector implements WalletConnectorPort {
     this.address = null;
   }
 
+  async isConnected(): Promise<boolean> {
+    return this.address !== null;
+  }
+
   async getAddress(): Promise<string | null> {
     return this.address;
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { WalletProvider } from '@/context/WalletContext';
+
+export const App: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+  <WalletProvider>{children}</WalletProvider>
+);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { WalletProvider } from '@/context/WalletContext';
+import { WalletProvider } from '@context/WalletContext';
+import { Home } from '@ui/views/Home';
 
-export const App: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
-  <WalletProvider>{children}</WalletProvider>
+export const App: React.FC = () => (
+  <WalletProvider>
+    <Home />
+  </WalletProvider>
 );

--- a/src/ui/components/ConnectButton.tsx
+++ b/src/ui/components/ConnectButton.tsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from 'react';
+import { useWallet } from '@context/WalletContext';
+
+export const ConnectButton: React.FC = () => {
+  const { connector } = useWallet();
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    connector.isConnected().then(setIsConnected).catch(() => setIsConnected(false));
+  }, [connector]);
+
+  const handleConnect = async () => {
+    try {
+      await connector.connect();
+      setIsConnected(true);
+    } catch (err) {
+      console.error('Connection failed:', err);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await connector.disconnect();
+      setIsConnected(false);
+    } catch (err) {
+      console.error('Disconnection failed:', err);
+    }
+  };
+
+  return (
+    <button onClick={isConnected ? handleDisconnect : handleConnect}>
+      {isConnected ? 'Disconnect Wallet' : 'Connect Wallet'}
+    </button>
+  );
+};

--- a/src/ui/views/Home.tsx
+++ b/src/ui/views/Home.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { ConnectButton } from '@ui/components/ConnectButton';
+
+export const Home: React.FC = () => (
+  <div>
+    <h1>Welcome to the Wallet Demo</h1>
+    <ConnectButton />
+  </div>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,12 +7,15 @@
     "paths": {
       "@core/*": ["core/*"],
       "@ui/*": ["ui/*"],
-      "@infra/*": ["infra/*"]
+      "@infra/*": ["infra/*"],
+      "@context/*": ["context/*"]
     },
     "outDir": "./dist",
     "esModuleInterop": true,
     "strict": true,
-    "types": ["node"]
+    "jsx": "react-jsx",
+    "lib": ["DOM", "ES2020"],
+    "types": ["node", "react"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add React dependencies
- configure tsconfig for React and context path
- create WalletContext with real wallet environment
- add App wrapper that provides wallet context
- export provider from package entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a15343f88333817a6322da00b117