### PR TITLE
Add connect/disconnect button component

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/src/ui/components/ConnectButton.module.css
+++ b/src/ui/components/ConnectButton.module.css
@@ -1,0 +1,8 @@
+.button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+.error {
+  color: red;
+  margin-top: 0.5rem;
+}

--- a/src/ui/components/ConnectButton.tsx
+++ b/src/ui/components/ConnectButton.tsx
@@ -1,35 +1,63 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useWallet } from '@context/WalletContext';
+import styles from './ConnectButton.module.css';
 
 export const ConnectButton: React.FC = () => {
   const { connector } = useWallet();
   const [isConnected, setIsConnected] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    connector.isConnected().then(setIsConnected).catch(() => setIsConnected(false));
+    connector
+      .isConnected()
+      .then(setIsConnected)
+      .catch(() => setIsConnected(false));
   }, [connector]);
 
   const handleConnect = async () => {
+    setLoading(true);
+    setError(null);
     try {
       await connector.connect();
       setIsConnected(true);
-    } catch (err) {
-      console.error('Connection failed:', err);
+    } catch (e) {
+      console.error('Failed to connect', e);
+      setError('Failed to connect');
+    } finally {
+      setLoading(false);
     }
   };
 
   const handleDisconnect = async () => {
+    setLoading(true);
+    setError(null);
     try {
       await connector.disconnect();
       setIsConnected(false);
-    } catch (err) {
-      console.error('Disconnection failed:', err);
+    } catch (e) {
+      console.error('Failed to disconnect', e);
+      setError('Failed to disconnect');
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <button onClick={isConnected ? handleDisconnect : handleConnect}>
-      {isConnected ? 'Disconnect Wallet' : 'Connect Wallet'}
-    </button>
+    <div>
+      <button
+        className={styles.button}
+        onClick={isConnected ? handleDisconnect : handleConnect}
+        disabled={loading}
+        aria-pressed={isConnected}
+      >
+        {isConnected ? 'Disconnect Wallet' : 'Connect Wallet'}
+      </button>
+      {error && (
+        <p role="alert" className={styles.error}>
+          {error}
+        </p>
+      )}
+    </div>
   );
 };

--- a/tests/ui/ConnectButton.test.tsx
+++ b/tests/ui/ConnectButton.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ConnectButton } from '@/ui/components/ConnectButton';
+import { WalletConnectorPort } from '@/core/application/ports/WalletConnectorPort';
+import { WalletContext } from '@/context/WalletContext';
+
+// Helper to render with a mocked connector via context
+function renderWithConnector(connector: WalletConnectorPort) {
+  const wrapper: React.FC<React.PropsWithChildren<{}>> = ({ children }) => (
+    <WalletContext.Provider value={{ connector } as any}>{children}</WalletContext.Provider>
+  );
+  return render(<ConnectButton />, { wrapper });
+}
+
+class MockConnector implements WalletConnectorPort {
+  connect = jest.fn(async () => {});
+  disconnect = jest.fn(async () => {});
+  isConnected = jest.fn(async () => this.connected);
+  getAddress = jest.fn(async () => (this.connected ? 'k:test' : null));
+  constructor(public connected = false) {}
+}
+
+describe('ConnectButton', () => {
+  it('renders connect state by default', async () => {
+    const connector = new MockConnector(false);
+    renderWithConnector(connector);
+    expect(screen.getByRole('button')).toHaveTextContent('Connect Wallet');
+  });
+
+  it('connects when clicked', async () => {
+    const connector = new MockConnector(false);
+    renderWithConnector(connector);
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(connector.connect).toHaveBeenCalled());
+  });
+
+  it('disconnects when clicked', async () => {
+    const connector = new MockConnector(true);
+    renderWithConnector(connector);
+    expect(screen.getByRole('button')).toHaveTextContent('Disconnect Wallet');
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(connector.disconnect).toHaveBeenCalled());
+  });
+
+  it('shows error on failure', async () => {
+    const connector = new MockConnector(false);
+    connector.connect = jest.fn(async () => { throw new Error('fail'); });
+    renderWithConnector(connector);
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => screen.getByRole('alert'));
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to connect');
+  });
+});


### PR DESCRIPTION
## Summary
- connect/disconnect flow managed via `ConnectButton`
- handle errors and loading states
- add CSS module styling and module typings
- include unit tests for `ConnectButton`

## Testing
- `npm run build`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6844ab5d56f48333930fcd7c695962b1