### PR TITLE
Add build scripts and network switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 # Simple Wallet Clone environment variables
-NODE_ENV=development
-NETWORK_HOST=https://api.testnet.chainweb.com
-NETWORK_ID=testnet04
+# Choose between 'devnet' or 'testnet'
+KADENA_NETWORK=devnet

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Each directory contains a `README.md` or `.gitkeep` to describe its purpose. Imp
 
 `WalletEnvironment.ts` under `src/core/application` exposes wallet services for development using mock adapters. Future integrations can switch implementations centrally without touching UI code.
 
-## Development
-
-Install dependencies and run the following commands:
+## Getting Started
 
 ```bash
-npm run dev    # start development server
-npm run build  # create production build
-npm run test   # run tests
+npm run install    # clean install
+npm run dev        # start with mock adapters
+npm run test       # run tests
+npm run build      # build production bundle
+npm run start      # serve production build
 ```
 
-The project currently contains no runtime logic or tests but the configuration allows teams to begin adding modules immediately.
+The project currently contains no runtime logic or tests but the scripts allow teams to bootstrap the demo quickly.

--- a/docs/INTEGRATION/adapter.md
+++ b/docs/INTEGRATION/adapter.md
@@ -22,8 +22,13 @@ import { WalletEnvironment } from '@core/application/WalletEnvironment';
 const adapter = new WalletAdapter(WalletEnvironment.connector);
 ```
 
-## Switch RPC URLs
-You can swap between devnet and testnet by passing different RPC URLs to `createWalletEnvironment()`.
+## Switching Network
+Set the `KADENA_NETWORK` environment variable to `testnet` before running any command to target Kadena testnet. The default is `devnet`.
+
+```bash
+export KADENA_NETWORK=testnet
+npm run dev
+```
 
 ## Connection Example
 ```ts

--- a/package.json
+++ b/package.json
@@ -3,16 +3,27 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "echo 'no dev server configured'",
-    "build": "tsc --build",
-    "test": "echo 'no tests yet'"
+    "install": "npm ci",
+    "dev": "NODE_ENV=development npm run build:mock && npm run serve:mock",
+    "build": "tsc && webpack --config webpack.prod.js",
+    "build:mock": "tsc && webpack --config webpack.mock.js",
+    "serve:mock": "node dist/mock/server.js",
+    "test": "jest --coverage",
+    "start": "serve -s dist"
   },
   "devDependencies": {
     "@types/events": "^3.0.3",
     "@types/node": "^22.15.30",
     "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.17",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11",
+    "webpack": "^5.91.0",
+    "webpack-cli": "^5.1.4",
+    "ts-loader": "^9.5.1",
+    "serve": "^14.2.0"
   },
   "dependencies": {
     "@kadena/wallet-sdk": "^0.2.1",

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,10 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import { createWalletEnvironment, WalletEnvironmentServices } from '@infra/sdk/createWalletEnvironment';
 
-const walletEnv: WalletEnvironmentServices = createWalletEnvironment(
-  'https://api.testnet.chainweb.com',
-  'testnet04',
-);
+const walletEnv: WalletEnvironmentServices = createWalletEnvironment();
 
 const WalletContext = createContext<WalletEnvironmentServices>(walletEnv);
 

--- a/src/core/application/WalletEnvironment.ts
+++ b/src/core/application/WalletEnvironment.ts
@@ -15,9 +15,7 @@ function createMockEnvironment(): WalletServices {
 }
 
 function createRealEnvironment(): WalletServices {
-  const networkHost = 'https://api.testnet.chainweb.com';
-  const networkId = 'testnet04';
-  return createWalletEnvironment(networkHost, networkId);
+  return createWalletEnvironment();
 }
 
 const nodeEnv = (globalThis as any).process?.env?.NODE_ENV;

--- a/src/infra/constants/networks.ts
+++ b/src/infra/constants/networks.ts
@@ -1,0 +1,2 @@
+export const DEVNET_RPC_URL = 'https://devnet.chainweb.com';
+export const TESTNET_RPC_URL = 'https://testnet.chainweb.com';

--- a/src/infra/sdk/createWalletEnvironment.ts
+++ b/src/infra/sdk/createWalletEnvironment.ts
@@ -1,11 +1,20 @@
 import { WalletSDKConnector } from './WalletSDKConnector';
 import { WalletSDKTransactionSigner } from './WalletSDKTransactionSigner';
 import { WalletSDKInfo } from './WalletSDKInfo';
+import { DEVNET_RPC_URL, TESTNET_RPC_URL } from '@infra/constants/networks';
 
 /**
  * Factory that instantiates the wallet services backed by the real SDK.
  */
-export function createWalletEnvironment(networkHost: string, networkId: string) {
+export function createWalletEnvironment() {
+  const network =
+    (globalThis as any).process?.env?.KADENA_NETWORK === 'testnet'
+      ? 'testnet'
+      : 'devnet';
+
+  const networkHost = network === 'testnet' ? TESTNET_RPC_URL : DEVNET_RPC_URL;
+  const networkId = network === 'testnet' ? 'testnet04' : 'development';
+
   return {
     connector: new WalletSDKConnector(networkHost, networkId),
     signer: new WalletSDKTransactionSigner(),

--- a/src/mock/server.ts
+++ b/src/mock/server.ts
@@ -1,0 +1,1 @@
+console.log('Mock server started');

--- a/webpack.mock.js
+++ b/webpack.mock.js
@@ -1,0 +1,9 @@
+const path = require('path');
+module.exports = {
+  mode: 'development',
+  entry: './dist/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+};

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,9 @@
+const path = require('path');
+module.exports = {
+  mode: 'production',
+  entry: './dist/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+};


### PR DESCRIPTION
## Summary
- add scripts for running app and tests
- let SDK pick devnet/testnet via `KADENA_NETWORK`
- document how to switch networks
- update getting started steps

## Testing
- `npm run test` *(fails: jest not found)*
- `npm run build` *(fails: ts compile error)*

------
https://chatgpt.com/codex/tasks/task_e_6844ac082534833396fed7141651812e